### PR TITLE
Include <errno.h> instead of the non-POSIX <sys/errno.h>

### DIFF
--- a/src/rpc_transport_low_latency_stubs.c
+++ b/src/rpc_transport_low_latency_stubs.c
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 #include <sys/uio.h>
-#include <sys/errno.h>
+#include <errno.h>
 
 #include <caml/mlvalues.h>
 #include <caml/bigarray.h>


### PR DESCRIPTION
Fixes build on OpenBSD, reported by krw@openbsd.org